### PR TITLE
Update TS guess generation notebook to fix a glitch related to atom mapping

### DIFF
--- a/notebooks/step1_ts_guess_generation.ipynb
+++ b/notebooks/step1_ts_guess_generation.ipynb
@@ -169,18 +169,20 @@
     "    \"\"\"\n",
     "\n",
     "    def decrement(m):\n",
-    "        return str(int(m.group()) - 1)\n",
+    "        return str(int(m.group().rstrip(']')) - 1) + \"]\"\n",
     "    \n",
     "    def increment(m):\n",
-    "        return str(int(m.group()) + 1)\n",
+    "        return str(int(m.group().rstrip(']')) + 1) + \"]\"\n",
     "\n",
     "    # Use a regular expression to find all the integers and decrement or increment each one\n",
+    "    # Note we search for \"{number}]\" to ensure that the number corresponds to an atom index.\n",
+    "    # Sometimes, SMILES strings include numbers to indicate connectivity i.e. in rings.\n",
     "    if mode == 'plus_one':\n",
-    "        new_smi = re.sub(r'\\d+', lambda m: increment(m), rxn_smi)\n",
+    "        new_smi = re.sub(r'\\d+]', lambda m: increment(m), rxn_smi)\n",
     "    elif mode == 'minus_one':\n",
-    "        new_smi = re.sub(r'\\d+', lambda m: decrement(m), rxn_smi)\n",
+    "        new_smi = re.sub(r'\\d+]', lambda m: decrement(m), rxn_smi)\n",
     "    else:\n",
-    "        raise ValueError(f'Specificed mode {mode} not recongized. Must be either plus_one or minus_one')\n",
+    "        raise ValueError(f'Specificed mode {mode} not recognized. Must be either plus_one or minus_one')\n",
     "    \n",
     "    return new_smi"
    ]
@@ -195,9 +197,14 @@
     "def test_adjust_atom_map_smi_indexing():\n",
     "    zero_idx_smi = '[H:10][C:15]([H:11])([H:12])[C:16]([H:13])([H:14])[F:17].[H:0][C:5]([H:1])([H:2])[S:9][C:6]([H:3])([H:4])[O:8][O:7]>>[H:11][C:15]([H:12])[C:16]([H:13])([H:14])[F:17].[H:0][C:5]([H:1])([H:2])[S:9][C:6]([H:3])([H:4])[O:8][O:7][H:10]'\n",
     "    one_idx_smi = '[H:11][C:16]([H:12])([H:13])[C:17]([H:14])([H:15])[F:18].[H:1][C:6]([H:2])([H:3])[S:10][C:7]([H:4])([H:5])[O:9][O:8]>>[H:12][C:16]([H:13])[C:17]([H:14])([H:15])[F:18].[H:1][C:6]([H:2])([H:3])[S:10][C:7]([H:4])([H:5])[O:9][O:8][H:11]'\n",
-    "    \n",
     "    assert adjust_atom_map_smi_indexing(rxn_smi=zero_idx_smi, mode='plus_one') == one_idx_smi\n",
     "    assert adjust_atom_map_smi_indexing(rxn_smi=one_idx_smi, mode='minus_one') == zero_idx_smi\n",
+    "    \n",
+    "    zero_idx_smi = '[C:0]([C:1]([C:2]([C:3]([Br:4])([H:22])[H:23])([H:20])[H:21])([H:18])[H:19])([H:15])([H:16])[H:17].[c:5]1([H:24])[c:6]([H:25])[c:7]([S-:8])[c:9]([H:26])[c:10]([H:27])[c:11]1[N+:12](=[O:13])[O-:14]'\n",
+    "    one_idx_smi  = '[C:1]([C:2]([C:3]([C:4]([Br:5])([H:23])[H:24])([H:21])[H:22])([H:19])[H:20])([H:16])([H:17])[H:18].[c:6]1([H:25])[c:7]([H:26])[c:8]([S-:9])[c:10]([H:27])[c:11]([H:28])[c:12]1[N+:13](=[O:14])[O-:15]'\n",
+    "    assert adjust_atom_map_smi_indexing(rxn_smi=zero_idx_smi, mode='plus_one') == one_idx_smi\n",
+    "    assert adjust_atom_map_smi_indexing(rxn_smi=one_idx_smi, mode='minus_one') == zero_idx_smi\n",
+    "    \n",
     "    \n",
     "test_adjust_atom_map_smi_indexing()"
    ]
@@ -222,7 +229,7 @@
     "    \"\"\"\n",
     "    \n",
     "    # Extract all integers from the string\n",
-    "    integers = [int(match) for match in re.findall(r'\\d+', rxn_smi)]\n",
+    "    integers = [int(match.rstrip(\"]\")) for match in re.findall(r'\\d+]', rxn_smi)]\n",
     "    \n",
     "    # Return the smallest integer if there's any integer in the string\n",
     "    return min(integers) if integers else None"
@@ -241,6 +248,9 @@
     "    \n",
     "    assert determine_atom_map_smi_indexing(rxn_smi=zero_idx_smi) == 0\n",
     "    assert determine_atom_map_smi_indexing(rxn_smi=one_idx_smi) == 1\n",
+    "    \n",
+    "    two_idx_smi = '[C:2]([C:3]([C:4]([C:5]([Br:6])([H:24])[H:25])([H:22])[H:23])([H:20])[H:21])([H:17])([H:18])[H:19].[c:7]1([H:26])[c:8]([H:27])[c:9]([S-:10])[c:11]([H:28])[c:12]([H:29])[c:13]1[N+:14](=[O:15])[O-:16]'\n",
+    "    assert determine_atom_map_smi_indexing(rxn_smi=two_idx_smi) == 2\n",
     "    \n",
     "test_determine_atom_map_smi_indexing()"
    ]
@@ -458,7 +468,7 @@
     "    \"\"\"\n",
     "\n",
     "    # Extract all integers from the string    \n",
-    "    int_list = [int(match) for match in re.findall(r'\\d+', rxn_smi)]\n",
+    "    int_list = [int(match.rstrip(\"]\")) for match in re.findall(r'\\d+\\]', rxn_smi)]\n",
     "    if sorted:\n",
     "        int_list.sort()\n",
     "\n",
@@ -475,7 +485,10 @@
     "def test_get_ordered_integers():\n",
     "    smi1 = '[H:10][C:15]([H:11])([H:12])[C:16]([H:13])([H:14])[F:17]'\n",
     "    assert get_ordered_integers(smi1) == [10, 15, 11, 12, 16, 13, 14, 17]\n",
-    "    \n",
+    "\n",
+    "    smi2 = '[c:5]1([H:24])[c:6]([H:25])[c:7]([S-:8])[c:9]([H:26])[c:10]([H:27])[c:11]1[N+:12](=[O:13])[O-:14]'\n",
+    "    assert get_ordered_integers(smi2) == [5, 24, 6, 25, 7, 8, 9, 26, 10, 27, 11, 12, 13, 14]\n",
+    "\n",
     "test_get_ordered_integers()"
    ]
   },
@@ -1325,7 +1338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Previous atom indexing did not account for edge cases where SMILES strings may have a number in the string to indicate connectivity (but not atom index). This change updates all atom mapping functions to handle those cases.

Example: `[C:0]([C:1]([C:2]([C:3]([Br:4])([H:22])[H:23])([H:20])[H:21])([H:18])[H:19])([H:15])([H:16])[H:17].[c:5]1([H:24])[c:6]([H:25])[c:7]([S-:8])[c:9]([H:26])[c:10]([H:27])[c:11]1[N+:12](=[O:13])[O-:14]>>[C:0]([C:1]([C:2]([C:3]([S:8][c:7]1[c:6]([H:25])[c:5]([H:24])[c:11]([N+:12](=[O:13])[O-:14])[c:10]([H:27])[c:9]1[H:26])([H:22])[H:23])([H:20])[H:21])([H:18])[H:19])([H:15])([H:16])[H:17].[Br-:4]`

note that `[c:11]1`  has a "1" that indicates connectivity, for example. Previously this would throw an error, but the code is now resilient to these and can detect these.

Also updated the unit tests to check for these cases.